### PR TITLE
use 64-bit environment so x64 blueiris binary is installed

### DIFF
--- a/Dockerfile
+++ b/Dockerfile
@@ -5,8 +5,8 @@ ENV DEBIAN_FRONTEND noninteractive
 ENV LC_ALL C.UTF-8
 ENV LANG en_US.UTF-8
 ENV LANGUAGE en_US.UTF-8
-ENV WINEPREFIX /root/prefix32
-ENV WINEARCH win32
+ENV WINEPREFIX /root/prefix
+#ENV WINEARCH win32
 ENV DISPLAY :0
 ENV BLUEIRIS_VERSION=5
 
@@ -43,8 +43,8 @@ RUN \
  chmod +x winetricks && \
  sh winetricks corefonts wininet
 
-RUN mv /root/prefix32 /root/prefix32_original && \
-    mkdir /root/prefix32
+RUN mv /root/prefix /root/prefix_original && \
+    mkdir /root/prefix
 
 # Expose Port
 EXPOSE 8080

--- a/blueiris.sh
+++ b/blueiris.sh
@@ -1,15 +1,15 @@
 #!/bin/bash
 
-BLUEIRIS_EXE="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}/BlueIris.exe"
-BLUEIRIS_INSTALL_PATH="/root/prefix32/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}"
-PREFIX_DIR="/root/prefix32"
+BLUEIRIS_EXE="/root/prefix/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}/BlueIris.exe"
+BLUEIRIS_INSTALL_PATH="/root/prefix/drive_c/Program Files/Blue Iris ${BLUEIRIS_VERSION}"
+PREFIX_DIR="/root/prefix"
 INSTALL_EXE="/root/blueiris.exe"
 
 if [ ! -d "$PREFIX_DIR/drive_c" ]; then
-    mv /root/prefix32_original/* /root/prefix32
+    mv /root/prefix_original/* /root/prefix
 fi
 
-chown -R root:root /root/prefix32
+chown -R root:root /root/prefix
 
 if [ ! -e "$BLUEIRIS_EXE" ] ; then
     if [ ! -e "$INSTALL_EXE" ] ; then


### PR DESCRIPTION
I think it's safe to assume that everyone will want the x64 binary.