### PR TITLE
Update service.reg

### DIFF
--- a/service.reg
+++ b/service.reg
@@ -15,5 +15,8 @@ Windows Registry Editor Version 5.00
 [HKEY_CURRENT_USER\Software\Wine\Drivers]
 "Audio"=""
 
+[HKEY_CURRENT_USER\Software\Wine\WineDbg]
+"ShowCrashDialog"=dword:00000000 
+
 [HKEY_LOCAL_MACHINE\System\CurrentControlSet\Control\Session Manager\Environment]
 "PATHEXT"=".COM;.EXE;.BAT;.CMD;.VBS;.VBE;.JS;.JSE;.WSF;.WSH;."


### PR DESCRIPTION
Sometimes Blue iris Crashes. This causes Blue iris to keep stuck untill you close the debug window. By adding this key the debug window will not be shown and blue iris will just restart. To me this seems desirable, to you too?